### PR TITLE
IGDD-1718 - Move Xform Console to new DNS dev.xform-ui.izgateway.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,4 +206,4 @@ jobs:
           aws-region: us-east-1
       - name: Deploy to Dev AWS
         run: |
-          aws ecs update-service --cluster izgateway-transformation-console --service izgateway-transform-console --force-new-deployment --enable-execute-command | jq ".service.deployments[].id"
+          aws ecs update-service --cluster xform-console-dev --service xform-console-dev --force-new-deployment --enable-execute-command | jq ".service.deployments[].id"


### PR DESCRIPTION
As part of a larger project to move Xform Console _off_ dev.xform.izgateway.org (so that Xform Service can use that) to dev.xform-ui.izgateway.org we created ECS clusters and services to better match our naming scheme.  This update simply changes the deploy to ecs update-service the proper cluster/service.