### PR TITLE
Adding code to Dockerfile to remove yarn.lock file from the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN adduser --system --uid 1001 nextjs
 RUN apk add bash
 
 COPY package.json package-lock.json ./
-RUN  npm ci --omit=dev --force
+RUN  npm ci --omit=dev --force && find. -type f -name 'yarn.lock' -delete
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/filebeat.yml ./filebeat.yml
 COPY --from=builder /app/metricbeat.yml ./metricbeat.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "izg-transformation-console",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "izg-transformation-console",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "dependencies": {
         "@axe-core/react": "^4.8.1",
         "@babel/types": "^7.22.5",


### PR DESCRIPTION
This change will help keep the vulnerability scans accurate.  AWS Inspector reported vulnerabilities found in the yarn.lock files, but these vulnerable modules were not actually part of the image.