### PR TITLE
IGDD-2157 - Update GitHub Action to deploy ECS tasks in multiple environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,5 +205,30 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy to Dev AWS
+        env:
+          AWS_REGIONS: ${{ vars.AWS_REGIONS }}
+          ECS_DESIRED_COUNT: ${{ vars.ECS_DESIRED_COUNT }}
         run: |
-          aws ecs update-service --cluster xform-console-dev --service xform-console-dev --force-new-deployment --enable-execute-command | jq ".service.deployments[].id"
+          if [ -z "$AWS_REGIONS" ]; then
+            echo "AWS_REGIONS not set, defaulting to us-east-1"
+            AWS_REGIONS="us-east-1"
+          fi
+          
+          if [ -z "$ECS_DESIRED_COUNT" ]; then
+            echo "ECS_DESIRED_COUNT not set, defaulting to 1"
+            ECS_DESIRED_COUNT="1"
+          fi
+          
+          for region in $AWS_REGIONS; do
+            echo "Update ECS services in $region (starting $ECS_DESIRED_COUNT containers)"
+            aws ecs update-service --region $region --cluster xform-console-dev --service xform-console-dev --force-new-deployment --enable-execute-command --desired-count $ECS_DESIRED_COUNT | jq ".service.deployments[].id" &
+          done
+          
+          wait
+          
+          for region in $AWS_REGIONS; do
+            echo "Wait for ECS service stability in $region"
+            aws ecs wait services-stable --region $region --cluster xform-console-dev --service xform-console-dev &
+          done
+          
+          wait


### PR DESCRIPTION
This updates the Github Action to provide ability to deploy updated images into all configured environments.

The AWS environments that will be deployed to can be configured via GitHub Settings -> Secrets and variables -> Actions -> Variables -> Repository Variables in the AWS_REGIONS variable. If that is not set the action will only deploy to us-east-1 by default. You set multiple regions by separating them by a space.

Also introduced a variable ECS_DESIRED_COUNT which tells the Action how many containers to start. If this is not set the default is 1. So if you have AWS_REGIONS set to us-east-1 and us-east-2, but do not set ECS_DESIRED_COUNT then 1 container will be started in each.

This allows us to change things without needing to change this file and do a PR. For instance, for costs, we may only want to run in 1 region for a while. So we can change AWS_REGIONS to only have one region.