### PR TITLE
IGDD-2181 - Update to push image to APHL with new requested naming

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -27,7 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releaseDate: ${{ steps.exposeValue.outputs.releaseDate }}
+      application_version: ${{ steps.get-version.outputs.version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
       - name: Get current date
         id: date
         run: echo "RELEASE_DATE=$(date +'%d%b%Y%H%M%S')" >> "$GITHUB_ENV"
@@ -35,6 +42,12 @@ jobs:
         id: exposeValue
         run: |
           echo "::set-output name=releaseDate::${{ env.RELEASE_DATE }}"
+      - name: Get Application Version
+        id: get-version
+        run: |
+          APPLICATION_VERSION=$(npm pkg get version | tr -d '"')
+          echo "version=${APPLICATION_VERSION}" >> $GITHUB_OUTPUT
+          echo "Application version: ${APPLICATION_VERSION}"
 
   code-quality-check:
     name: Test and Lint
@@ -111,8 +124,8 @@ jobs:
             ${{ env.GITHUB_REGISTRY_PREFIX }}/${{ env.GITHUB_REGISTRY_NAME }}/izg-transformation-ui
             ${{ steps.login-ecr.outputs.registry }}/izg-transformation-ui
           tags: |
-            type=raw,value=${{ needs.generate-release-timestamp.outputs.releaseDate }}
-            type=raw,value=release
+            type=raw,value=${{ needs.generate-release-timestamp.outputs.application_version }}-${{github.run_number}}
+            type=raw,value=release-${{ needs.generate-release-timestamp.outputs.application_version }}-${{github.run_number}}
           flavor: |
             latest=true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releaseDate: ${{ steps.exposeValue.outputs.releaseDate }}
+      application_version: ${{ steps.get-version.outputs.version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
       - name: Get current date
         id: date
         run: echo "RELEASE_DATE=$(date +'%d%b%Y%H%M%S')" >> "$GITHUB_ENV"
@@ -30,6 +37,12 @@ jobs:
         id: exposeValue
         run: |
           echo "::set-output name=releaseDate::${{ env.RELEASE_DATE }}"
+      - name: Get Application Version
+        id: get-version
+        run: |
+          APPLICATION_VERSION=$(npm pkg get version | tr -d '"')
+          echo "version=${APPLICATION_VERSION}" >> $GITHUB_OUTPUT
+          echo "Application version: ${APPLICATION_VERSION}"
 
   code-quality-check:
     name: Test and Lint
@@ -115,9 +128,9 @@ jobs:
             ${{ env.GITHUB_REGISTRY_PREFIX }}/${{ env.GITHUB_REGISTRY_NAME }}/izg-transformation-ui,enable=${{ contains(github.ref, 'refs/heads/release/') }}
             ${{ steps.login-ecr.outputs.registry }}/izg-transformation-ui
           tags: |
-            type=raw,value=${{ needs.generate-release-timestamp.outputs.releaseDate }}
-            type=raw,value=release,enable=${{ contains(github.ref, 'refs/heads/release/') }}
-            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ needs.generate-release-timestamp.outputs.application_version }}-${{github.run_number}}
+            type=raw,value=${{ needs.generate-release-timestamp.outputs.application_version }}-${{github.run_number}}-release,enable=${{ contains(github.ref, 'refs/heads/release/') }}
+            type=raw,value=${{ needs.generate-release-timestamp.outputs.application_version }}-${{github.run_number}}-snapshot,enable=${{ github.ref == 'refs/heads/develop' }}
           flavor: |
             latest=true
 
@@ -158,12 +171,6 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
             ${{ runner.os }}-nextjs-
 
-      - name: "Get Application Version"
-        run: |
-          echo "Setting the release version"
-          APPLICATION_VERSION=$(npm pkg get version | tr -d '"')
-          echo APPLICATION_VERSION="${APPLICATION_VERSION}" >> $GITHUB_ENV
-
       - name: Configure AWS credentials (APHL)
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -182,7 +189,7 @@ jobs:
           images: |
             ${{ secrets.APHL_ECR_REGISTRY }}/${{ secrets.APHL_ECR_REPOSITORY }},enable=${{ contains(github.ref, 'refs/heads/release/') }}
           tags: |
-            type=raw,value=izgw-transf-ui-${{ env.APPLICATION_VERSION }}_${{github.run_number}}
+            type=raw,value=izgw-transf-ui-${{ needs.generate-release-timestamp.application_version }}-${{github.run_number}}
           flavor: |
             latest=false
 


### PR DESCRIPTION
Update name of image pushed to APHL when release is cut, per request. Also only push one tag, per request. 

GitHub Organization Secrets have been updated

- APHL_ECR_REGISTRY = 273687833332.dkr.ecr.us-east-1.amazonaws.com/izgateway-ha
- APHL_ECR_REPOSITORY = ecr-repo
- APHL_AWS_ACCESS_KEY_ID = you can find value in AWS secrets
- APHL_AWS_SECRET_ACCESS_KEY = you can find value in AWS secrets