### PR TITLE
chore(deps): security and dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/tcp-ping": "^0.1.6",
         "@types/xml2js": "^0.4.14",
         "@xmldom/xmldom": "^0.9.10",
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "http-status-codes": "^2.3.0",
         "lodash": "^4.18.1",
         "moment": "^2.30.1",
@@ -45,9 +45,9 @@
         "react-dom": "^18.3.1",
         "react-to-print": "^2.15.1",
         "saml2-js": "^4.0.4",
-        "swagger-ui-react": "^5.32.5",
+        "swagger-ui-react": "^5.32.6",
         "swr": "^2.4.1",
-        "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
+        "uuid": "npm:@izgateway/uuid-cjs@^14.0.7",
         "waait": "^1.0.5",
         "winston": "^3.19.0",
         "xml-crypto": "^3.2.1",
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
         "@commitlint/config-conventional": "^17.8.1",
-        "@izgateway/dependency-scripts": "^1.0.1",
+        "@izgateway/dependency-scripts": "^1.0.2",
         "@next/eslint-plugin-next": "^16.2.6",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.3.1",
@@ -1828,9 +1828,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1846,9 +1843,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1866,9 +1860,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1884,9 +1875,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1904,9 +1892,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1922,9 +1907,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1942,9 +1924,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1961,9 +1940,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1979,9 +1955,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2005,9 +1978,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2029,9 +1999,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2055,9 +2022,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2079,9 +2043,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2105,9 +2066,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2130,9 +2088,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2154,9 +2109,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2429,9 +2381,9 @@
       }
     },
     "node_modules/@izgateway/dependency-scripts": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@izgateway/dependency-scripts/1.0.1/d69015910d309a9beb98095d45bc5e904a9a7415",
-      "integrity": "sha512-xxm1uijNam4DBqM5qkh99+7hdKWwwCnM91C50HvnXvgygEc4augSGImC/tj8XPTiUw7JgCLze3SnHg+LeQvqQA==",
+      "version": "1.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@izgateway/dependency-scripts/1.0.2/552006c2d8704b54a56eddae411728a634920e64",
+      "integrity": "sha512-IMcCOChCGIvgjtBcGlNUu39em9mMiX9ozixtnZGH/+Lrm9AXXxdB9RijQyzxMCgUdI4WHxUomfSzWzx5so8zvw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3526,9 +3478,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3544,9 +3493,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3564,9 +3510,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3582,9 +3525,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3812,13 +3752,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.0.tgz",
-      "integrity": "sha512-poLd6eNipLCFCrxjZD+E9E0Z85CLfFzueNiVcYj86rwMp2OszYsTzZS2jz82yR/usNCjXCpkQ2xEXWSmDhefPg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.1.tgz",
+      "integrity": "sha512-5vcFzXltmIpCsjQouVKzjj7pPPUxYmwIARHuenim96GDnmqqVTtAoBXpIX++cD5RcJA72EBEqepQ+VSAA12RPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3826,14 +3766,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.0.tgz",
-      "integrity": "sha512-7TvbbC3dG3yM8cjqyrFXoTOpwgOC68+Z17Ro36drJwZ0k/c7QQc0dI/KvTSPHn9UfimEMdZ0q+yIIzqrAiEmww==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.1.tgz",
+      "integrity": "sha512-KsN0dZBsutUGWtbsqBMvQ+3pJUjq/wRRABCNIG2Ys/1Ctq8FaQaA0MoICPuYgDZCUNsZuJYbw6Swm6e0GaHWtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -3843,37 +3783,37 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.0.tgz",
-      "integrity": "sha512-JPt37oOrf73CAZNQBPffnLzU5iEUs8cT9pFmc9vy2gHQp+vjSKxeJ9F6zagTp8VnLPUq0gVjIvCQvcX8NPW2jA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.1.tgz",
+      "integrity": "sha512-7KV2Ac4BOcrv4yJz7T5DbZiTdqbnVUT+g68Hjhabl5zhD28mfEEn9V8Zq2D6rtjlCYkqWAMFb8Y6Y+9ssH5wgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.0.tgz",
-      "integrity": "sha512-11JWHr55FciYGTbcicNZrBsFEwNuLLZybi00YHJ3OBcuXcFJPKmKluLnVL7GhZYEqvLYOcVsCfInYW5MXoj00w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.1.tgz",
+      "integrity": "sha512-c8QSUgQxDolTO+rP2bvX4CrZOrnTMTAMh0xGq8LaYvzVzs0bQT7ZApsbcA/4bzWlwcg6wy2Uuw+qMadl1FNR3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.0.tgz",
-      "integrity": "sha512-IskDsUkUtNas4guoChRKKkw0wOst64nRA24WuIjLf8ztfBdcl/oqx/cgy8pwWCUqNYvL9L3+sD5HeuokqMrySw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.1.tgz",
+      "integrity": "sha512-2K3Ix+nRHDkuixkZ4FAMWY5MAJHipzpFvZrRtneZ7hsx7nObw9HYEXZw/yXuYrvnhC8jsE4z91Gwuvvz7ZjfPw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3881,15 +3821,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.0.tgz",
-      "integrity": "sha512-n+aGSlLHyrpmCaBa9DBZkIqnNVzYAYSa010MvAwhlwtW3EbFYNwYWinbTwLqCd3leN6XWTvQYCvk0/k7/9Cq4A==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.1.tgz",
+      "integrity": "sha512-rnICw0uXnKeNHUaS+Ip7lxtVXqH1iA3zFlX446e4XAamJd6yU28sujIsGiZ71qPQ217teidkfK7Bx7MktHdiEw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3897,15 +3837,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.0.tgz",
-      "integrity": "sha512-SHh3naFZlXFI0gG36tNYvJ/VO8aZsjnXIQAqJHfOE6rrpl5msJrdDatmNczh+57WPZxEZA+KTXWCqNKdeu3G3Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.1.tgz",
+      "integrity": "sha512-syABiWLeWRfKoonUhPriPVwDDeEOlN5RD20Dj/MS9DT5r1BJUrAB1BfRRRHsVhzaXVdUcKKH99iC9C842J9kvA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3913,15 +3853,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.0.tgz",
-      "integrity": "sha512-4vrgNYDj68hgmgZj1eGBaBr5xqIETWn4jAioiRHek4jV1FLvmxCs3nC2nYs8CzQqqJ1bqirdiirrUpqhaQvTEA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.1.tgz",
+      "integrity": "sha512-y4syE8jOEGuSirc3YaeI0dh3rEvHfc/pERQOTj3KofS2IABpBXTmtg+oDfG2zte1/Cyc/eJ6qecVAns5mhBpow==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3929,15 +3869,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.0.tgz",
-      "integrity": "sha512-5avPMY1YbQmJIqXlu7rm3yftf4xhT2REBxpEgw8Nc7Zlbn4Z5iGXBsHr60982MwqeE6W8wA+HHQMKHM5siuhdQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.1.tgz",
+      "integrity": "sha512-1SNXikZN2uQ1YZ3A4dzWBoMN6wTkba1qZdy/NOkweFtoLuBb63KKN/gD1e6chQV8+ikqGn8TTUZnYvX6SVBZ6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3945,15 +3885,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.0.tgz",
-      "integrity": "sha512-zddyOxWKlQ9WPaZR0e8ykmy8AbGnDvqCqqy6BdYqKZ9Ts8ZK1XwOB2j9ruccZpoiy/rp2tow+CUf3XE5rricmQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.1.tgz",
+      "integrity": "sha512-oyvTkjDXI9k3G8oVHOvpL/t1MfZmx8d7rgeNqsm6j/vK6WlOXIOHdN9LTYRo8YdACaWq/JV5B30grkio/HRMKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3961,14 +3901,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.0.tgz",
-      "integrity": "sha512-upc0xKb3nxsYPECRDf5UygnZHTSj78xHj5+SBIHNDXoaGDhvMCtWoDVGAKFtZ+jZlIkyJt7cGAeOX0w9IV3XkA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.1.tgz",
+      "integrity": "sha512-Ha23zkVSItmFZbAoSKMI7hwYJT7yTMWO+EcNzDBEClsqRrkcCtvF2YsiQZcyUt5SrEwV8rW0TWE0CVG+WEs2zg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-core": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3976,15 +3916,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.0.tgz",
-      "integrity": "sha512-sd/U6Y34uRqdgd3Phz1oEhO7UBCn60+OfIasFFpHZcKe7O0jTmayiaJqbpwirhwt7Fv5Ev5m58+y1nVomLnhQw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.1.tgz",
+      "integrity": "sha512-Gm4ULCg4yulfjZiMIbH1XiiKHI/BqK0zc1GexViiLShXS35/2dc27GmpI0YgV7S+DqvivNrwAkqojeN7ho9/NA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3992,15 +3932,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.0.tgz",
-      "integrity": "sha512-7ptuxmuh2vN1hDr3cLkYm2rl+ak2J1byoGxswucKfSb+7IaFoA36/t7kcOsE/hIO4yI7T3ZPOuNSpeg1NBVjEw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.1.tgz",
+      "integrity": "sha512-OHW4Qb0BqbHJ3QoQcGREE5bobMeBkZzSQe/0RFGayhI1HJZqrmwtot2nLAuie9sQJoj/xeUprOsA/he06NVFEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4008,16 +3948,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.0.tgz",
-      "integrity": "sha512-cAIPJhLxm/nj1kzneNySeaTahY+hH5gkGNsgbmifGnLPsC5YOOfEVMKLj18IREdXqdnxJgRbsI9Azl4g09TPkg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.1.tgz",
+      "integrity": "sha512-yXHJmyN+NyF2xBD6KlFmGuMrf1hKqK9pm/FwStepIUqvn6bfTGgEdUi5BivQuErRrN6NtQczFF21Jlu6jjg86Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4025,15 +3965,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.0.tgz",
-      "integrity": "sha512-IUEWVSuETE5DdgTJhIt6oZyRTYUV892/I9UdyTResR0Bypc7gy3YXwlzMlUZx73S2klaiFo1dL4iu/fqzA2fEg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.1.tgz",
+      "integrity": "sha512-R2zHd33OiVT5eTlYKS1FyVDP0G76ymdP2EIrBPbM1FDKam1kRIRdgZA2StCd9PY4oNp/LqQKMnfe9wdLWZS3AA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4041,17 +3981,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.0.tgz",
-      "integrity": "sha512-WpUvFgOs4YMUmyeJRQEADps+U5o71YTtzKMPNr1cF1ZHKKkcRMUJL9QlJ4Y9cxAdjo6oXzXZa5922XOpwMYhxA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.1.tgz",
+      "integrity": "sha512-FtoW4wkFO1VSHu6G+wUZ71hQhIOuastJPyWEePbfySE4Uiz+01t/X/ODnl2OHRGVUYFoJa7kJi5/xqcsprdxtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-json-pointer": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-json-pointer": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4059,18 +3999,18 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.0.tgz",
-      "integrity": "sha512-mUErHIq8rHVoOrkHnRj3mhoNYVIl8th474/m0+E8OB2wBAe0KgiczaJX9KkBQoAo5XIxoRfmI5T3bp+fRabwCA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.1.tgz",
+      "integrity": "sha512-ILJAgp6mHwoV8rRuKYD3QuvPdcRcmK9YmAfrsjgC7fJM7irqzC+nBOKhrWVpTAee7r3b+B3HpV5MG8aKGd9qNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-json-pointer": "^1.11.0",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-json-pointer": "^1.11.1",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4078,144 +4018,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.0.tgz",
-      "integrity": "sha512-0OdwcnV/QF+Vs3Vj0dTmlRHEp9WQg9aBvWWl8Fq25OviyDhGGRpqgkEAOjtVYCH3XyZ1Xz+jhIDOdd5pxBajsA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.1.tgz",
+      "integrity": "sha512-bCt1/7NPfCznhq2D3Y1UcZowdxMtr6wGCISMSPf3ziaCcOQhy7sG/nWEzS/rwcKCVNefVft833Ab3jaCWGivJw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.0.tgz",
-      "integrity": "sha512-K714DT6nFW+ZM9LTo+c120zkUjsEcIFO2DU+0cnzReRyenb1x6RZe+uOqTt7iWohnnWp2FV/j0exd/mCsxW65Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.1.tgz",
+      "integrity": "sha512-hUcshr5ydn/L4VsgP5nyrFDp4QqIADrx5nQnFddw/OWCNi1Al19ccPxuBh1Qlf421AAmk1oUiybeGyduvRsVPQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.0.tgz",
-      "integrity": "sha512-z9K6XEr3AafV2EA+1pfW+8VoMCCSSpm2IU7oUTjSnhxRb5t/DZR4Qg8FEK8tRKdS2BO2kFFLb2xikrY3Qx8B+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.1.tgz",
+      "integrity": "sha512-8ydiEnlSJ7DPhFqg9Z11u4Vda16yaOuIGLablI0mOnYoAMTlqnteGk5CDPlVb970VBTYvsNlgW+164XfHAU/6w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.0.tgz",
-      "integrity": "sha512-HPb7Wzr+cj0IJkRRlqsK1tNCQXivuGRP4iB2yek16sQZXo2eqSUZ3j3Lz/WwWgnN/FWGAODm4bj9+EhGQ11TnA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.1.tgz",
+      "integrity": "sha512-G4++rZDMKokEfq78EJ2aE7pgd1Xo70XIn1/ikSiT5awfuhPJzNcV99ZdzQI2xVVU/pbKIL2Vc/b5SP1IRlfCwA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.0.tgz",
-      "integrity": "sha512-sQenLXZRmTDQehe3JCSQpz6jpE3DhMQ0aoe2gpNqo23Gt/4oeW6nAP2h49q9Ne+CHPp0ApFUUyIXF7UTmbUWqA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.1.tgz",
+      "integrity": "sha512-7Npn4LkG4q95b2VimG3SV0lqgG3xPeF5Srq+sVbG7iFd4yDubvEVy5zzqx5QH4tOtATdarhv6glA9j3hTfWBdQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.0.tgz",
-      "integrity": "sha512-aGnG3AYp4Qsimn1FOP0B9leYCJAQVockzHqyJj30xiNAXquBMXr6lq3L2/AEsmpDGv/x/++YJ4p2ggSxy12QNw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.1.tgz",
+      "integrity": "sha512-/C1CzsnUW2ZMBg4kWYrhrfqmyjb4aGo9+YaySQwdArLfM8l2HCOQqDEteGIivedVEsmTpVdhC60gdb6N2VzSaQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.0.tgz",
-      "integrity": "sha512-iIRlB8B46UPiu0EkKhq1TvwloBgObASJ5ROx8rhT5+Pj+BBegE+KIY02EUKwcz5FgXJrH3XcltLiI7ZA68347Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.1.tgz",
+      "integrity": "sha512-0Xfu8PLM787el0R7lwjFfQYe0Bpv3Jz0YlkEiQqAVvftVb0oNi8tg9FhDTR8ju/N94gpNXIfaH/5Ahgz5G+NKg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.0.tgz",
-      "integrity": "sha512-BF2ZyQYMUNrjP1nMneX6ZD2IWBLycWpxg3yllXDCJtfdQT/IMzldIPKCNI9qoBE57lM6j2hpy+Jd86QJk20t2w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.1.tgz",
+      "integrity": "sha512-DqoR43NsFBmiJW1h2Xg3n2V6NQx+95qJ3ziA9rIbKJHGCidHtjNJgi4I7sWGnaIApIHijYY2bW22MKXaT0a0cQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.0.tgz",
-      "integrity": "sha512-DObW0LxYwif0erzGoXiEAZ6ecc/18LIEKxjEAc5Bw2M5I0C/iGW4y/UxAywihGvhMEo1gOvdO6w9Jh6UnuPVmA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.1.tgz",
+      "integrity": "sha512-L8XFzTbEknHDhD40M/pSoDlimjlYaXXWZS4AmyD3i+XRfiDWWVhEWHPE9OTNk6UL8R6DOBm3RSDxAd5xpLoPjg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -4225,144 +4165,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.0.tgz",
-      "integrity": "sha512-dREUHAEHVry9aSGjqDpYF9Wzm1lgUkV6EgoYDflyQ9HxgCwhucDPFmUgI7UaR0G6bplnJumMcZXh1I1TGn1v7Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.1.tgz",
+      "integrity": "sha512-s9xZa/h4Yiz+Qc304s+9JSTPFsToYtSWQCeyA9jkHOWy/Oq8ZjD9wg34IjENS3yBqM1YLz6Dk+PX06DcyAOnnw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.0.tgz",
-      "integrity": "sha512-U/NZpvuj9IpUS48zF2tYbgW2AtTw6Yi6kXNiHUtgUEomxYdb6XQeKLDGvgeWjgAgfUROohakcH+wx713VCGxfQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.1.tgz",
+      "integrity": "sha512-dLGaVn24N+YZRB0vzQMC4R+aiSNfD81Xcp5TwdEbE+jOeOnoOe5NqzqCWjaDpSMChDsK/NdaSDjQj4uiYfWpug==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.0.tgz",
-      "integrity": "sha512-fYarNeaz39oKZ6VwqwON+IeJszidZGPvUYDfggLaar81NGimrz07y1U+DhAf96IX3qgUa2J6Fu3Bv1r57hs6Ng==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.1.tgz",
+      "integrity": "sha512-EnYF3rzPZoiCYDnp4ChB6K15RUV4rE6QfEh7fTEwIlkWMUKv4oVwZd8aqz2i9laRZiBH6S2uUoED8YNtCNbeIg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.0.tgz",
-      "integrity": "sha512-jtMoAH3R73bQUc4D2cJTUUvO4iJz9CV1W4+zoU/gT2l6h8Ji5EhZH0/VyynUk4J6mW/GdwxUN/q5z2P/DtSmfA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.1.tgz",
+      "integrity": "sha512-digw37g+k/rg87HHMUHuSZVWH1Kh8OjC8SmQflIh1Oot9fGhmnZWddsws+sKWSVy6/HveuZPykL8bxtSV3Nc/A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.0.tgz",
-      "integrity": "sha512-e8L4kHahgkOIzCCSGs5jTahXLInERNr37teSLS4SuqYgSVWr9AVXuNvpHNYGeMECD8briGIGfAAtnZChCGYrEA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.1.tgz",
+      "integrity": "sha512-b38GFur/NjjLFBCVR/wo7DRF6EW5h8B5jBe7C17EVaJvg9eRzknnr9/KMnxYeTtjQVO8W/JeY7LlLad1/j0pcA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.0.tgz",
-      "integrity": "sha512-s+AXnNzLeAk28jUAeXwTSR1AlX+TXIAt2GfFgWUAV+SFw2OhRpoKYLzItN3n2UsHselqHvfyUL9xNCJBZleQtQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.1.tgz",
+      "integrity": "sha512-dza6Bwe5kLL+4jANuaScxvYh3o7RxESp6Riz6M09cXRysyRrHFQ7UYuUhxepSD4jSiSxJQS8nu0i547i6Z7W7Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.0.tgz",
-      "integrity": "sha512-xyUyehHhB+BSOAT7mYGqmcEozuLKxmx1Hug97O9SVgNU8QTClc95+VWrAHhJbn8juPR6y2vSwm/wrQDwb4yq7w==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.1.tgz",
+      "integrity": "sha512-PgmolQN1PYdROSo/cHNyXINVD+aLmW6VqfwT7potNo08c4aWj+QQ/a0Az+mldfJ+G98WjNRvEKr8dhEw8zfqmw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.0.tgz",
-      "integrity": "sha512-u7Y98zdjEs+0Upa8TdxOsb7z8hYJmLz9lVleRiB7rqysVga6oSDI5NAFdLVqMB6uAUuFi/tyiuiFT4Qosfd6Vw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.1.tgz",
+      "integrity": "sha512-+nmtJ3/wPLBBN6d8xI8rD0mOz80V4iSRe6rYYOQ/skel673N1SY4B58Ufnc7KnMNV4cOce/a52ASQ1Qd1csLvQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.0.tgz",
-      "integrity": "sha512-FZK9KfwiTnNc+imxg7Wu2ktKhXCYPeFQZ1uZJzJL/hk1n+zyPfRY/4Aue4HzDcG8+wbItd3dRjKClFanVZAXoA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.1.tgz",
+      "integrity": "sha512-KEgk5PoSmmLC7ZvH0+RF4FPyWAj0NyrPFbTr04DmNPznfr2qpGqvt3ZBmAJm82jrWoI1dc8EH1ugT1YX69N8ww==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-ast": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -4404,46 +4344,46 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.0.tgz",
-      "integrity": "sha512-ftqegYrxxl9UwQFbdVOtXIqNolVd25M5u53X8fP96Wx6lEVr5Ed7B6+dzch8ttCUmKeoLIeagvt76b6BoYtnLw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.1.tgz",
+      "integrity": "sha512-wxsRo12YVc2Q4o81K9EGzX5oM1htNDkeCIRkLyg1wPvzFQUH4khd6aOWYaX/0V0L+7yqwwmeW/t80xV8qLEGAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.1",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "minimatch": "^10.2.1",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.11.0",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0"
+        "@swagger-api/apidom-json-pointer": "^1.11.1",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1"
       }
     },
     "node_modules/@swaggerexpert/cookie": {
@@ -5334,9 +5274,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5351,9 +5288,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5368,9 +5302,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5385,9 +5316,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5402,9 +5330,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5419,9 +5344,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5436,9 +5358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5453,9 +5372,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5941,14 +5857,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -12374,26 +12316,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -12421,23 +12343,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-fetch-commonjs": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
-      "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-forge": {
@@ -15254,9 +15159,9 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.37.3",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.3.tgz",
-      "integrity": "sha512-PZv5smQPnPwfP6mnkq96fOp/RNDKBqd8vfwE4UuwA229wsesj20yd7RadXx+9uLBC3c0H6cu/H+bnbMTWG6oUQ==",
+      "version": "3.37.4",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.4.tgz",
+      "integrity": "sha512-3xxqc9s99Vsf47ket2j7D4Tw6b6T7ObNvTqSP009yBeoAo0fy0yprqOVxFISTrvRxN7jgfrEi8GXMhsjzb1M0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
@@ -15273,11 +15178,13 @@
         "js-yaml": "^4.1.0",
         "neotraverse": "=0.6.18",
         "node-abort-controller": "^3.1.1",
-        "node-fetch-commonjs": "^3.3.2",
         "openapi-path-templating": "^2.2.1",
         "openapi-server-url-templating": "^1.3.0",
         "ramda": "^0.30.1",
         "ramda-adjunct": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/swagger-jsdoc": {
@@ -15374,9 +15281,9 @@
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.32.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.5.tgz",
-      "integrity": "sha512-u86Qx36C5FvmJFVGMF3s62dxR3l0EfUmlylJVqCJ4vL0tvfd38kNdCQan9app6Y+C25uqVAjGLYu2w87UMD35Q==",
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.6.tgz",
+      "integrity": "sha512-2q2kXd6eDR+syyWV5HE2CkWANyr2MHPkNezG4M7fC0FPlBUZEsNgyA/2dcb9dIwgE5xd995dO42h89fNMF5/ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
@@ -15408,7 +15315,7 @@
         "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.12",
-        "swagger-client": "^3.37.3",
+        "swagger-client": "^3.37.4",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -16438,15 +16345,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/web-tree-sitter": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/tcp-ping": "^0.1.6",
     "@types/xml2js": "^0.4.14",
     "@xmldom/xmldom": "^0.9.10",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "http-status-codes": "^2.3.0",
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
@@ -55,9 +55,9 @@
     "react-dom": "^18.3.1",
     "react-to-print": "^2.15.1",
     "saml2-js": "^4.0.4",
-    "swagger-ui-react": "^5.32.5",
+    "swagger-ui-react": "^5.32.6",
     "swr": "^2.4.1",
-    "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
+    "uuid": "npm:@izgateway/uuid-cjs@^14.0.7",
     "waait": "^1.0.5",
     "winston": "^3.19.0",
     "xml-crypto": "^3.2.1",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
-    "@izgateway/dependency-scripts": "^1.0.1",
+    "@izgateway/dependency-scripts": "^1.0.2",
     "@next/eslint-plugin-next": "^16.2.6",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
@@ -104,7 +104,7 @@
     "postcss": "^8.5.14",
     "prismjs": "^1.30.0",
     "sha.js": "^2.4.12",
-    "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
+    "uuid": "npm:@izgateway/uuid-cjs@^14.0.7",
     "yaml": "^1.10.3"
   }
 }


### PR DESCRIPTION
# Security and Dependency Update Summary

## 🔒 Automated Security & Dependency Updates

This PR updates dependencies to their latest **minor versions** and addresses security vulnerabilities at all severity levels.

### Changes Made:
- ✅ Updated dependencies to latest compatible minor versions
- ✅ Fixed all vulnerabilities (updated direct deps + added overrides)
- ✅ Removed unnecessary overrides (where all resolved versions meet requirements)
- ✅ Updated `package-lock.json`
- ✅ Ran linting, type-checking, and tests
- ✅ Built application successfully

### Package Changes:
```diff
diff --git a/package.json b/package.json
index 668f861..8c1eaa6 100644
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/tcp-ping": "^0.1.6",
     "@types/xml2js": "^0.4.14",
     "@xmldom/xmldom": "^0.9.10",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "http-status-codes": "^2.3.0",
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
@@ -55,9 +55,9 @@
     "react-dom": "^18.3.1",
     "react-to-print": "^2.15.1",
     "saml2-js": "^4.0.4",
-    "swagger-ui-react": "^5.32.5",
+    "swagger-ui-react": "^5.32.6",
     "swr": "^2.4.1",
-    "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
+    "uuid": "npm:@izgateway/uuid-cjs@^14.0.7",
     "waait": "^1.0.5",
     "winston": "^3.19.0",
     "xml-crypto": "^3.2.1",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
-    "@izgateway/dependency-scripts": "^1.0.1",
+    "@izgateway/dependency-scripts": "^1.0.2",
     "@next/eslint-plugin-next": "^16.2.6",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
@@ -104,7 +104,7 @@
     "postcss": "^8.5.14",
     "prismjs": "^1.30.0",
     "sha.js": "^2.4.12",
-    "uuid": "npm:@izgateway/uuid-cjs@^14.0.0",
+    "uuid": "npm:@izgateway/uuid-cjs@^14.0.7",
     "yaml": "^1.10.3"
   }
 }
```

### Review Checklist:
- [ ] Review version changes in `package.json`
- [ ] Verify no breaking changes in release notes
- [ ] Check that all tests pass
- [ ] Confirm security audit results
- [ ] Test locally if needed

---
**Generated:** 2026-05-15 04:38:35 UTC
**Workflow Run:** [25900507694](https://github.com/IZGateway/izg-transformation-ui/actions/runs/25900507694)