### PR TITLE
fix(ci): add dependency_scripts_channel input to security-updates workflow

### DIFF
--- a/.github/workflows/security-updates.yml
+++ b/.github/workflows/security-updates.yml
@@ -4,7 +4,16 @@ on:
   schedule:
     # Run daily at 3:15 AM UTC (avoids conflict with E2E tests at 7 AM)
     - cron: '15 3 * * *'
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      dependency_scripts_channel:
+        description: 'npm tag for @izgateway/dependency-scripts (use "dev" to test pre-release changes)'
+        required: false
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - dev
 
 permissions:
   contents: write
@@ -65,7 +74,9 @@ jobs:
       - name: Install security tooling
         run: |
           npm install -g npm-check-updates
-          npm install -g @izgateway/dependency-scripts
+          SCRIPTS_CHANNEL="${{ inputs.dependency_scripts_channel || 'latest' }}"
+          npm install --no-save @izgateway/dependency-scripts@${SCRIPTS_CHANNEL}
+          echo "Using @izgateway/dependency-scripts@$(node -p \"require('./node_modules/@izgateway/dependency-scripts/package.json').version\")"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
## Summary

Adds a \`dependency_scripts_channel\` input to the \`workflow_dispatch\` trigger so manual runs can select the \`@dev\` channel of \`@izgateway/dependency-scripts\` for testing pre-release changes before they ship as \`@latest\`.

Scheduled runs are unaffected — they default to \`latest\`.

Also fixes the install step: the existing \`npm install -g\` was installing globally but the workflow invokes scripts via \`node node_modules/...\`, which uses the *local* install. Switching to \`npm install --no-save\` ensures the correct version is actually used.

## How to test a pre-release fix

1. Open **Actions → Security Updates → Run workflow**
2. Set **dependency_scripts_channel** to \`dev\`
3. Run — the workflow will install \`@izgateway/dependency-scripts@dev\` and use it for all script invocations

## Related

- izg-dependency-scripts PR #3 — brace-expansion eslint scoped override fix (the first change to test with this mechanism)
- Once izg-dependency-scripts PR #3 merges, PR #226 in this repo can be closed without merging (the fix moves to the script itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)