### PR TITLE
ci: pin Docker actions to commit SHAs for supply-chain security

### DIFF
--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         # Always login: GHCR credentials are needed to pull the private base image.
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -377,7 +377,7 @@ jobs:
         run: echo "ts=$(date +'%d%b%Y%H%M%S')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Login to the GitHub Container registry
         id: login-ghcr
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ${{ env.GITHUB_REGISTRY_PREFIX }}
           username: ${{ github.actor }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: |
             ${{ env.GITHUB_REGISTRY_PREFIX }}/${{ env.GITHUB_REGISTRY_NAME }}/izg-transformation-ui
@@ -131,7 +131,7 @@ jobs:
 
       - name: Build and push Docker Xform Console image
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Cache Next.js build
         uses: actions/cache@v5
@@ -120,7 +120,7 @@ jobs:
       - name: Login to the GitHub Container registry
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
         id: login-ghcr
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ${{ env.GITHUB_REGISTRY_PREFIX }}
           username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: |
             ${{ env.GITHUB_REGISTRY_PREFIX }}/${{ env.GITHUB_REGISTRY_NAME }}/izg-transformation-ui,enable=${{ contains(github.ref, 'refs/heads/release/') }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Build and push Docker Xform Console image
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## Summary

Pins Docker GitHub Actions to immutable commit SHAs instead of movable version tags.

**Why:** A movable tag (e.g. `@v7`) can be silently updated by a compromised upstream account to point to malicious code. A commit SHA pin is immutable — your workflow always runs the exact bytes you reviewed.

## Changes

| Action | Before | After |
|---|---|---|
| `docker/build-push-action` | `@v7` | `@f9f3042f7e27…` (v7) |
| `docker/login-action` | `@v4` | `@650006c6eb7d…` (v4) |
| `docker/metadata-action` | `@v6` | `@80c7e94dd9b9…` (v6) |
| `docker/setup-buildx-action` | `@v4` | `@d7f5e7f509e4…` (v4) |

## Keeping SHAs up to date

Dependabot is already configured on these repos (added in IGDD-2803). It will automatically open PRs when these SHAs need to advance to a newer release — no manual tracking needed.

## Test plan

- [ ] Verify workflows still trigger and pass on this branch
- [ ] Confirm Docker build/push steps complete successfully