### PR TITLE
chore: No longer install nginx in xform console Dockerfile

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # izg-transformation-ui (Xform Console) — Project Instructions
 
 Next.js web app for managing IZ Gateway transformation pipelines. Package name: `izg-transformation-console`.
-AWS ECS (Fargate) + nginx + Docker.
+AWS ECS (Fargate) + nginx (provided by the base image) + Docker.
 
 **Public repo** — follow IZ Gateway Public Repo Policy (in global CLAUDE.md).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 
 - **Package name:** `izg-transformation-console`
 - **Version cadence:** semantic versioning; see `RELEASE_NOTES.md`
-- **Deployed on:** AWS ECS (Fargate), behind nginx, using Docker
+- **Deployed on:** AWS ECS (Fargate), behind nginx (provided by the Docker base image, not installed in this repo's Dockerfile), using Docker
 - **Jira component:** `Transformation Console`
 - **OpenSpec repo:** CRs live in this repo under `openspec/changes/`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,11 @@ RUN apk add --no-cache tini
 
 COPY package.json package-lock.json ./
 
+# nginx is no longer installed here (IGDD-3010) — it is provided by the base image.
+# Fail the build fast if a future base image stops shipping nginx, rather than
+# discovering it at container runtime when run_and_monitor.sh tries to start it.
+RUN command -v nginx >/dev/null || { echo "ERROR: nginx not found, should be installed in base image."; exit 1; }
+
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN
 RUN apk add --no-cache curl libc6-compat \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/replace-variable.sh ./replace-var
 COPY --from=builder /app/run_and_monitor.sh ./run_and_monitor.sh
 
 # Replace default filebeat config with custom config file
- RUN cd ../filebeat && \
+RUN cd ../filebeat && \
      rm -rf /filebeat.yml && \
      cp ../app/filebeat.yml ./filebeat.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,14 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 RUN apk add bash
 
-# Install Nginx, gettext (for envsubst), and tini
-RUN apk add --no-cache nginx tini
+# Install gettext (for envsubst), and tini
+RUN apk add --no-cache tini
 
 COPY package.json package-lock.json ./
 
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN
-RUN apk add --no-cache bash nginx gettext tini curl libc6-compat \
+RUN apk add --no-cache bash gettext tini curl libc6-compat \
     && npm config set @izgateway:registry https://npm.pkg.github.com/ \
     && npm config set //npm.pkg.github.com/:_authToken ${NPM_TOKEN} \
     && npm ci --omit=dev && find . -type f -name 'yarn.lock' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ COPY package.json package-lock.json ./
 # Fail the build fast if a future base image stops shipping the nginx binary or the
 # 'nginx' user that nginx.conf's `user nginx;` directive requires, rather than
 # discovering it at container runtime when run_and_monitor.sh tries to start nginx.
-RUN if ! command -v nginx >/dev/null 2>&1; then echo "ERROR: nginx binary not found; must be provided by the base image."; exit 1; fi
-RUN if ! id -u nginx >/dev/null 2>&1; then echo "ERROR: 'nginx' user not found; required by 'user nginx;' in nginx.conf."; exit 1; fi
+RUN if ! command -v nginx >/dev/null 2>&1; then echo "ERROR: nginx binary not found; must be provided by the base image."; exit 1; fi \
+    && if ! id -u nginx >/dev/null 2>&1; then echo "ERROR: 'nginx' user not found; required by 'user nginx;' in nginx.conf."; exit 1; fi
 
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,14 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 RUN apk add bash
 
-# Install gettext (for envsubst), and tini
+# Install tini
 RUN apk add --no-cache tini
 
 COPY package.json package-lock.json ./
 
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN
-RUN apk add --no-cache bash gettext tini curl libc6-compat \
+RUN apk add --no-cache curl libc6-compat \
     && npm config set @izgateway:registry https://npm.pkg.github.com/ \
     && npm config set //npm.pkg.github.com/:_authToken ${NPM_TOKEN} \
     && npm ci --omit=dev && find . -type f -name 'yarn.lock' -delete
@@ -55,10 +55,7 @@ COPY --from=builder /app/next.config.js ./next.config.js
 COPY --from=builder --chown=nextjs:nodejs /app/replace-variable.sh ./replace-variable.sh
 COPY --from=builder /app/run_and_monitor.sh ./run_and_monitor.sh
 
-# Install filebeat
-RUN apk add curl libc6-compat
-
-# Replace default filebeat config with custom config file 
+# Replace default filebeat config with custom config file
  RUN cd ../filebeat && \
      rm -rf /filebeat.yml && \
      cp ../app/filebeat.yml ./filebeat.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,11 @@ RUN apk add --no-cache tini
 COPY package.json package-lock.json ./
 
 # nginx is no longer installed here (IGDD-3010) — it is provided by the base image.
-# Fail the build fast if a future base image stops shipping nginx, rather than
-# discovering it at container runtime when run_and_monitor.sh tries to start it.
-RUN command -v nginx >/dev/null || { echo "ERROR: nginx not found, should be installed in base image."; exit 1; }
+# Fail the build fast if a future base image stops shipping the nginx binary or the
+# 'nginx' user that nginx.conf's `user nginx;` directive requires, rather than
+# discovering it at container runtime when run_and_monitor.sh tries to start nginx.
+RUN command -v nginx >/dev/null 2>&1 || { echo "ERROR: nginx binary not found; must be provided by the base image."; exit 1; } \
+    && id -u nginx >/dev/null 2>&1 || { echo "ERROR: 'nginx' user not found; required by 'user nginx;' in nginx.conf."; exit 1; }
 
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
-RUN apk add bash
-
-# Install tini
-RUN apk add --no-cache tini
+# Install bash and tini
+RUN apk add --no-cache bash tini
 
 COPY package.json package-lock.json ./
 
@@ -44,8 +42,8 @@ COPY package.json package-lock.json ./
 # Fail the build fast if a future base image stops shipping the nginx binary or the
 # 'nginx' user that nginx.conf's `user nginx;` directive requires, rather than
 # discovering it at container runtime when run_and_monitor.sh tries to start nginx.
-RUN command -v nginx >/dev/null 2>&1 || { echo "ERROR: nginx binary not found; must be provided by the base image."; exit 1; } \
-    && id -u nginx >/dev/null 2>&1 || { echo "ERROR: 'nginx' user not found; required by 'user nginx;' in nginx.conf."; exit 1; }
+RUN if ! command -v nginx >/dev/null 2>&1; then echo "ERROR: nginx binary not found; must be provided by the base image."; exit 1; fi
+RUN if ! id -u nginx >/dev/null 2>&1; then echo "ERROR: 'nginx' user not found; required by 'user nginx;' in nginx.conf."; exit 1; fi
 
 # Install Dependencies and cleanup yarn.lock if present
 ARG NPM_TOKEN


### PR DESCRIPTION
Installation of nginx is handled by Base Image.

Adds check to make sure nginx does exist on the base image. Without this it's possible this "build" would work and create a docker image. But when the shell script that starts all services ran it would fail because nginx wasn't installed.  This check lets the build fail here in GitHub so it's not discovered downstream.