### PR TITLE
fix(security): prevent full req/res objects from being logged (IGDD-2794)

### DIFF
--- a/src/pages/api/api-middleware-helper.ts
+++ b/src/pages/api/api-middleware-helper.ts
@@ -5,6 +5,7 @@ import logger from '../../../logger'
 import hasAccessToDestId from '../../lib/accesshelper'
 
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info'
+let hasLoggedDebugWarning = false
 
 // Catch any errors
 const captureErrors: Middleware = async (req, res, next) => {
@@ -21,25 +22,34 @@ const captureErrors: Middleware = async (req, res, next) => {
 const logRequest: Middleware = async (req, res, next) => {
   const session = await getServerSession(req, res, authOptions)
   const user = session?.user?.email || null
-  if (LOG_LEVEL.toLocaleLowerCase() === 'debug') {
+  const isDebug = LOG_LEVEL.toLowerCase() === 'debug'
+
+  if (isDebug && !hasLoggedDebugWarning) {
     logger.warn(
       'WARNING: LOG_LEVEL is set to DEBUG, this will log sensitive information for every API request'
     )
+    hasLoggedDebugWarning = true
+  }
+
+  await next()
+
+  if (isDebug) {
     logger.info('API Request ' + req.url, {
       req,
       res,
+      statusCode: res.statusCode,
       user,
       'x-forwarded-for': req.headers['x-forwarded-for'] || null,
       'user-agent': req.headers['user-agent'] || null,
     })
   } else {
     logger.info('API Request ' + req.url, {
+      statusCode: res.statusCode,
       user,
       'x-forwarded-for': req.headers['x-forwarded-for'] || null,
       'user-agent': req.headers['user-agent'] || null,
     })
   }
-  await next()
 }
 
 // check access to destination

--- a/src/pages/api/api-middleware-helper.ts
+++ b/src/pages/api/api-middleware-helper.ts
@@ -1,9 +1,10 @@
 import { label, Middleware } from 'next-api-middleware'
 import { authOptions } from './auth/[...nextauth]'
 import { getServerSession } from 'next-auth'
-import { decode } from 'next-auth/jwt'
 import logger from '../../../logger'
 import hasAccessToDestId from '../../lib/accesshelper'
+
+const LOG_LEVEL = process.env.LOG_LEVEL || 'info'
 
 // Catch any errors
 const captureErrors: Middleware = async (req, res, next) => {
@@ -18,18 +19,26 @@ const captureErrors: Middleware = async (req, res, next) => {
 
 // log the api requests and response code
 const logRequest: Middleware = async (req, res, next) => {
-  const sessionToken =
-    req.cookies['next-auth.session-token'] ||
-    req.cookies['__Secure-next-auth.session-token']
-  const session = await decode({
-    token: sessionToken,
-    secret: process.env.NEXTAUTH_SECRET,
-  })
-  logger.debug('Api request ' + req.url, {
-    req,
-    res,
-    user: session.email || null,
-  })
+  const session = await getServerSession(req, res, authOptions)
+  const user = session?.user?.email || null
+  if (LOG_LEVEL.toLocaleLowerCase() === 'debug') {
+    logger.warn(
+      'WARNING: LOG_LEVEL is set to DEBUG, this will log sensitive information for every API request'
+    )
+    logger.info('API Request ' + req.url, {
+      req,
+      res,
+      user,
+      'x-forwarded-for': req.headers['x-forwarded-for'] || null,
+      'user-agent': req.headers['user-agent'] || null,
+    })
+  } else {
+    logger.info('API Request ' + req.url, {
+      user,
+      'x-forwarded-for': req.headers['x-forwarded-for'] || null,
+      'user-agent': req.headers['user-agent'] || null,
+    })
+  }
   await next()
 }
 
@@ -39,18 +48,12 @@ const checkAccessToDestId: Middleware = async (req, res, next) => {
   const session = await getServerSession(req, res, authOptions)
   const hasAccess = hasAccessToDestId(destId, session)
   if (hasAccess) {
-    logger.debug('Api request ' + req.url, {
-      req,
-      res,
-      user: session.user.email,
-    })
     await next()
   } else {
     res.status(401).send('unauthorized')
-    logger.debug('Api request ' + req.url, {
-      req,
-      res,
-      user: session.user.email,
+    logger.warn('Unauthorized access attempt', {
+      url: req.url,
+      user: session?.user?.email || null,
     })
   }
 }
@@ -60,18 +63,12 @@ const checkAccessToDestIdSlug: Middleware = async (req, res, next) => {
   const session = await getServerSession(req, res, authOptions)
   const hasAccess = hasAccessToDestId(destId, session)
   if (hasAccess) {
-    logger.debug('Api request ' + req.url, {
-      req,
-      res,
-      user: session.user.email,
-    })
     await next()
   } else {
     res.status(401).send('unauthorized')
-    logger.debug('Api request ' + req.url, {
-      req,
-      res,
-      user: session.user.email,
+    logger.warn('Unauthorized access attempt', {
+      url: req.url,
+      user: session?.user?.email || null,
     })
   }
 }


### PR DESCRIPTION
## Summary

Fixes IGDD-2794: https://izgateway.atlassian.net/browse/IGDD-2794

Replaces debug-only full req/res logging in api-middleware-helper.ts with a safe pattern matching izg-configuration-console:

- Info level (default/production): logs only user, x-forwarded-for, and user-agent -- no full request/response objects
- Debug level: full req/res logging preserved but gated behind LOG_LEVEL=debug, with a warn emitted to alert operators
- checkAccessToDestId / checkAccessToDestIdSlug: full req/res debug calls removed; unauthorized paths now log a targeted warn with url and user

## Files Changed
- src/pages/api/api-middleware-helper.ts